### PR TITLE
Sanitise docker tag strings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
    Jenkins instance at: http://ok-jenkins.uksouth.cloudapp.azure.com/ 
 */
 
-String dockerTag = "${env.BUILD_TAG}".toLowerCase()
+String dockerTag = "${env.BUILD_TAG}".toLowerCase().replaceAll("[^\\p{IsAlphabetic}^\\p{IsDigit}]", "-")
 
 // Run in declarative pipeline
 pipeline {


### PR DESCRIPTION
Docker tags only support alphanumeric characters plus _-. characters:
 https://docs.docker.com/engine/reference/commandline/tag/#usage

Add in a replace to strip out all non-alphanumerics which might get into
the docker tag field and replace with hyphens. This is overzealous for the
tag restrictions but should be safe.