### PR TITLE
Change worker label in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                // Docker and native builds are independent of each other
                parallel {
                     stage('OK docker') {
-                         agent { label 'linux' }
+                         agent { label 'azure-linux' }
                          steps {
                               // docker methods need to drop into scripted pipeline    
                               script {
@@ -46,7 +46,7 @@ pipeline {
                     }
 
                     stage('OK native') {
-                         agent { label 'linux' }
+                         agent { label 'azure-linux' }
                          steps {
                               sh 'sudo apt-get update'
                               // Required for pip and later installs


### PR DESCRIPTION
'linux' as a worker label is ambiguous when moving to a non-dedicated Jenkins master which should run ICOKPy tests on an azure VM worker. Changing the label to ICOKPy to be more discriminating as to their workers.