### PR TITLE
Remove double-test in native build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,6 @@ pipeline {
                               sh 'curl https://bootstrap.pypa.io/get-pip.py | sudo python3'
                               sh 'sudo pip install -r requirements.txt'
                               sh 'sudo pip install pytest-timeout python-coveralls'
-                              sh 'py.test tests/ --ignore=tests/test_job.py'
                               sh 'py.test --cov-report term-missing --cov=server tests/  --ignore tests/test_web.py --timeout=30'
                          }
                     }


### PR DESCRIPTION
Jenkins is double-testing in the native build - this was introduced as a check back in repo prehistory and has somehow slipped through into master. It needs to be removed. Begone, double-test!