### PR TITLE
fixes hard-coding of an App_id in test and uses proper app.config now 

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -30,7 +30,7 @@ class RunTests(Command):
         test_runner.run(test_suite)
 
 
-manager.add_command("server", Server(host='localhost', use_reloader=True))
+manager.add_command("server", Server(host='localhost'))
 manager.add_command("show-urls", ShowUrls())
 manager.add_command("clean", Clean())
 manager.add_command('db', MigrateCommand)

--- a/server/controllers/auth.py
+++ b/server/controllers/auth.py
@@ -125,9 +125,16 @@ def microsoft_user_data(token):
 
     try:
         decoded_token = jwt.decode(token, verify=False)
-        return {'email': decoded_token['preferred_username']}
-    except requests.exceptions.Timeout as e:
-        logger.error("Unable to decode token from Microsoft")
+        if 'unique_name' in decoded_token: # Azure V1 endpoints
+            return {'email': decoded_token['unique_name']} 
+        if 'preferred_username' in decoded_token:  # Azure V2 endpoints
+            return {'email': decoded_token['preferred_username']}
+
+        logger.error("Unable to retreive unique_name from token - which is email")
+        return None
+    except jwt.DecodeError as e:
+        logger.error("jwt Decode error from token")
+        logger.error('Decode error was %s', e)
         return None
 
 def user_from_provider_token(token):

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -26,9 +26,12 @@ GOOGLE = dict(
 MICROSOFT = dict(
     consumer_key=os.getenv('MICROSOFT_APP_ID'), # TODO: make these generic across provider
 	consumer_secret=os.getenv('MICROSOFT_APP_SECRET'),
+    tenent_id=os.getenv('MICROSOFT_TENANT_ID', 'common'),
     base_url='https://management.azure.com',
     request_token_url=None,
     access_token_method='POST',
-    access_token_url='https://login.microsoftonline.com/common/oauth2/token',
-    authorize_url='https://login.microsoftonline.com/common/oauth2/authorize?resource=c0bbcec8-3f72-4e97-941c-1950300696b6' #?resource=https://management.azure.com/'
+    access_token_url='https://login.microsoftonline.com/{tenant_id}/oauth2/token' \
+        .format(tenant_id=os.getenv('MICROSOFT_TENANT_ID', 'common')),
+    authorize_url='https://login.microsoftonline.com/{tenant_id}/oauth2/authorize?resource={application_id}' \
+        .format( application_id=os.getenv('MICROSOFT_APP_ID'), tenant_id=os.getenv('MICROSOFT_TENANT_ID', 'common'))
 )


### PR DESCRIPTION
two things - fixes the flow and removed some hard-code app_id. 
1. Now uses the env variables:
```
MICROSOFT_TENANT_ID=csenyc.onmicrosoft.com 
MICROSOFT_APP_SECRET=ibSMghG/XlqN0kwaYe4fhLRu6JX6lL1iBE6ZyWh2tM4=
MICROSOFT_APP_ID=545af5b9-acac-4620-a755-8e980c065886
```
***MICROSOFT_TENANT_ID***
Retrieve from [Azure Portal](https://portal.azure.com) under the *Active Directory* blade, then Properties.
***MICROSOFT_APP_ID***
This is from the Application registered in the Azure AD Tenant. Again, from the Azure AD blade on the portal go to *Registered Applications*
***MICROSOFT_APP_SECRET***
For that same APP_ID, you must generate a **secret** which is also under *Registered Application* Setttings.

2. Also, a flag added for reload during dev was added, but now removed. this was a Flask switch.