### PR TITLE
fix refresh vs full access token

### DIFF
--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -32,6 +32,12 @@ MICROSOFT = dict(
     access_token_method='POST',
     access_token_url='https://login.microsoftonline.com/{tenant_id}/oauth2/token' \
         .format(tenant_id=os.getenv('MICROSOFT_TENANT_ID', 'common')),
-    authorize_url='https://login.microsoftonline.com/{tenant_id}/oauth2/authorize?resource={application_id}' \
-        .format( application_id=os.getenv('MICROSOFT_APP_ID'), tenant_id=os.getenv('MICROSOFT_TENANT_ID', 'common'))
+    authorize_url='https://login.microsoftonline.com/{tenant_id}/oauth2/authorize' \
+        .format(tenant_id=os.getenv('MICROSOFT_TENANT_ID', 'common')),
+        request_token_params={
+        'resource' : os.getenv('MICROSOFT_APP_ID'),
+        'response_mode' : 'query',
+        # 'scope': 'email profile',
+        'prompt': 'login'
+    }
 )


### PR DESCRIPTION
this should fix the lack of a both access and refresh token on the single call to /authorize on the V1 OAuth2 endpoint

This WILL force user to login prompt each time. Without the forced login prompt, anything else the token issued at that moment is only an Access Code, and the current code/library doesn't use that to obtain a access token.  

Now, the token has both access and ID token in it with this push on each time. but forces the login